### PR TITLE
GLOBAL_QUOTE api is no longer returning current date for TSX: securities

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ yarn install --offline
 ```sh
 # you backed this up right?
 rm database.sqlite
-node scripts/migrate.js
+yarn node scripts/migrate.js
 ```
 
 # Import data

--- a/cron/neo-tracker
+++ b/cron/neo-tracker
@@ -1,7 +1,5 @@
 # Do update/current once an hour from 10am to 4pm, sleeping up to 50 minutes beforehand.
-# At 6pm, do the daily update.
 # At midnight, back up the sqlite file.
 # vim:ft=crontab
 0 10-16 * * 1-5     nobody    perl -le 'sleep rand 3000' && curl --silent --insecure --request POST https://localhost/app/update/current >/dev/null
-0 18    * * 1-5     nobody    curl --silent --insecure --request POST https://localhost/app/update/daily >/dev/null
 55 23   * * 1-5     andy      /home/andy/neo-tracker/scripts/sqlite3-backup.sh

--- a/lib/getPrices.js
+++ b/lib/getPrices.js
@@ -2,7 +2,6 @@ const fetch = require('node-fetch');
 const fs = require('fs');
 const chrome = require('selenium-webdriver/chrome');
 const webdriver = require('selenium-webdriver');
-const moment = require('moment');
 
 const alphavantageKey = fs.readFileSync('alpha_vantage_key.txt', 'utf8').trim();
 const alphavantageSleep = 61000 / 5; // free api limit is 5 per minute
@@ -105,12 +104,8 @@ async function alphavantageFetch(row) {
         }
         return;
       }
-      if (moment().format('YYYY-MM-DD') === gq['07. latest trading day']) {
-        const price = gq['05. price'];
-        r.price = price || '';
-        return;
-      }
-      r.err = 'latest trading day is not today';
+      r.date = gq['07. latest trading day'] || '';
+      r.price = gq['05. price'] || '';
     })
     .catch((err) => {
       r.err = `${err.toString().trim()} - [keys in resp:${jsonKeys}]`;

--- a/migrations/003-drop-daily-price.sql
+++ b/migrations/003-drop-daily-price.sql
@@ -1,0 +1,14 @@
+-- Up
+DROP TABLE current_price;
+
+-- Down
+CREATE TABLE current_price (
+    stock_id INTEGER,
+    price REAL,
+    time INTEGER,
+    CONSTRAINT current_price_fk_stock_stock_id
+        FOREIGN KEY (stock_id) REFERENCES stock(stock_id)
+);
+
+CREATE UNIQUE INDEX uniq_current_price_stock_id
+    ON current_price (stock_id);

--- a/routes/all.js
+++ b/routes/all.js
@@ -20,8 +20,11 @@ router.get('/', async (req, res, next) => {
         maxmin AS (
           SELECT MAX(price) AS max,MIN(price) AS min,stock_id FROM daily_price where date > date('now','-1 year') GROUP BY stock_id
         ),
+        latest_date AS (
+          SELECT MAX(date) AS updated,stock_id FROM daily_price GROUP BY stock_id
+        ),
         latest AS (
-          SELECT price,datetime(time,'localtime') AS updated,stock_id FROM current_price
+          SELECT price, updated, dp.stock_id FROM daily_price dp JOIN latest_date ld ON dp.stock_id = ld.stock_id AND dp.date = ld.updated
         )
         SELECT symbol,max,min,avg50day,avg200day,price,updated
         FROM stock

--- a/routes/current.js
+++ b/routes/current.js
@@ -9,7 +9,16 @@ const { sqlite } = require('../lib/db');
 router.get('/:symbol', async (req, res, next) => {
   try {
     const priceRow = await sqlite().get(
-      'SELECT price FROM current_price JOIN stock USING (stock_id) WHERE symbol = ?',
+      `
+      WITH
+      latest_date AS (
+        SELECT MAX(date) AS date,stock_id FROM daily_price GROUP BY stock_id
+      )
+      SELECT price
+      FROM daily_price dp
+      JOIN latest_date ld USING (stock_id,date)
+      JOIN stock USING (stock_id) WHERE symbol = ?
+      `,
       req.params.symbol
     );
     if (typeof priceRow === 'undefined') {

--- a/routes/update.js
+++ b/routes/update.js
@@ -44,13 +44,13 @@ router.post('/current', async (req, res, next) => {
       .then((prices) =>
         sqlite()
           .prepare(
-            'REPLACE INTO current_price (stock_id,price,time) VALUES (?,?,datetime(?))'
+            'REPLACE INTO daily_price (stock_id,price,date) VALUES (?,?,?)'
           )
           .then((sth) =>
             prices.reduce(async (acc, p) => {
               await acc;
               if (!p.err && p.price) {
-                return sth.run(p.stock_id, p.price, 'now');
+                return sth.run(p.stock_id, p.price, p.date);
               }
               if (p.err) {
                 // eslint-disable-next-line no-console
@@ -66,22 +66,6 @@ router.post('/current', async (req, res, next) => {
             }, Promise.resolve())
           )
       );
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.post('/daily', async (req, res, next) => {
-  try {
-    await sqlite()
-      .run(
-        'INSERT OR IGNORE INTO daily_price (stock_id,price,date) ' +
-          'SELECT stock_id,price,date(?) FROM current_price ' +
-          '  WHERE date(time) = date(?)',
-        'now',
-        'now'
-      )
-      .then(() => res.sendStatus(204));
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
- fix by not checking that today is the date returned by the endpoint,
  and always REPLACE INTO'ing the daily_price table for the stock and
  given date for the GLOBAL_QUOTE call
- this makes the current_price table redundant if we rewrite some
  queries to use the latest daily_price row instead, so drop it
- and remove the endpoint that copies from current_price to daily_price